### PR TITLE
[FEAT/TEST] 유저의 필수요소 제거시 테스트코드 추가

### DIFF
--- a/src/main/java/blueharmel/strokehigh/domain/User.java
+++ b/src/main/java/blueharmel/strokehigh/domain/User.java
@@ -5,7 +5,6 @@ import blueharmel.strokehigh.domain.enums.UserState;
 import blueharmel.strokehigh.domain.enums.UserType;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,9 +34,9 @@ public class User extends DeletedTimeEntity {
     private String password;
 
     @Enumerated(EnumType.STRING)
-    @ColumnDefault("'ACTIVE'")
     @Column(name = "user_state", nullable = false)
-    private UserState userState; // 유저 상태 [ACTIVE, INACTIVE, BANNED]
+    @Builder.Default
+    private UserState userState = UserState.ACTIVE; // 유저 상태 [ACTIVE, INACTIVE, BANNED]
 
     @Enumerated(EnumType.STRING)
     @Column(name = "social_type")
@@ -47,9 +46,9 @@ public class User extends DeletedTimeEntity {
     private String socialId;
 
     @Enumerated(EnumType.STRING)
-    @ColumnDefault("'COMMON'")
     @Column(name = "user_type", nullable = false)
-    private UserType userType; // 유저 종류 [ADMIN, COMMON]
+    @Builder.Default
+    private UserType userType = UserType.COMMON; // 유저 종류 [ADMIN, COMMON]
 
     @OneToMany(mappedBy = "user")
     private List<MatchParticipation> participations = new ArrayList<>();

--- a/src/test/java/blueharmel/strokehigh/service/UserServiceTest.java
+++ b/src/test/java/blueharmel/strokehigh/service/UserServiceTest.java
@@ -1,11 +1,14 @@
 package blueharmel.strokehigh.service;
 
 import blueharmel.strokehigh.domain.User;
+import blueharmel.strokehigh.domain.enums.UserState;
+import blueharmel.strokehigh.domain.enums.UserType;
 import blueharmel.strokehigh.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -24,7 +27,7 @@ class UserServiceTest {
     @Test
     public void 회원가입() throws Exception {
         //given
-        User user = User.builder().nickname("kim").build();
+        User user = User.builder().username("홍길동").nickname("kim").email("dldjdtjr@naver.com").password("1234").userState(UserState.valueOf("ACTIVE")).userType(UserType.valueOf("COMMON")).build();
         //when
         Long savedId = userService.join(user);
         //then
@@ -35,11 +38,23 @@ class UserServiceTest {
     @Test
     public void 중복_회원_예외() throws Exception {
         //given
-        User user1 = User.builder().nickname("kim").build();
-        User user2 = User.builder().nickname("kim").build();
+        User user1 = User.builder().username("홍길동").nickname("kim").email("dldjdtjr@naver.com").password("1234").userState(UserState.valueOf("ACTIVE")).userType(UserType.valueOf("COMMON")).build();
+        User user2 = User.builder().username("홍길동").nickname("kim").email("dldjdtjr@naver.com").password("1234").userState(UserState.valueOf("ACTIVE")).userType(UserType.valueOf("COMMON")).build();
         //when, then
         userService.join(user1);
         assertThrows(IllegalStateException.class, () -> {
+            userService.join(user2);
+        });
+    }
+
+    @Test
+    public void 필수요소_제외_후_가입시도() throws Exception {
+        //given
+        User user1 = User.builder().username("홍길동").nickname("kim").email("dldjdtjr@naver.com").password("1234").build(); // Enum은 설정된 Default 값이 반영
+        User user2 = User.builder().username("홍길동").build();
+        //when,then
+        userService.join(user1);
+        assertThrows(DataIntegrityViolationException.class, () -> {
             userService.join(user2);
         });
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
#15 

## 📝작업 내용

> 1. 유저 엔티티의 필수 요소를 제거하고 요청을 보내면 에러 발생
> 2. ENUM 타입들은 기본값으로 설정된 정보가 넘어가서 입력하지 않아도 그대로 넘어감