### PR TITLE
[FEAT/TEST] 유저 생성 메소드 추가/테스트 분할

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     // 쿼리 파라미터를 로그로 남기는 라이브러리
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+    // 소셜 로그인 관련 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/src/main/java/blueharmel/strokehigh/domain/DeletedTimeEntity.java
+++ b/src/main/java/blueharmel/strokehigh/domain/DeletedTimeEntity.java
@@ -4,8 +4,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -14,7 +12,7 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class DeletedTimeEntity extends BaseTimeEntity {
-    @CreatedDate
+
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 

--- a/src/main/java/blueharmel/strokehigh/domain/User.java
+++ b/src/main/java/blueharmel/strokehigh/domain/User.java
@@ -13,9 +13,10 @@ import java.util.List;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 public class User extends DeletedTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
@@ -50,27 +51,69 @@ public class User extends DeletedTimeEntity {
     @Builder.Default
     private UserType userType = UserType.COMMON; // 유저 종류 [ADMIN, COMMON]
 
+    //연관관계 필드들(빌더에서 제외)
     @OneToMany(mappedBy = "user")
+    @Builder.Default
     private List<MatchParticipation> participations = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    List<Rivalry> rivalries = new ArrayList<>();
+    @Builder.Default
+    private List<Rivalry> rivalries = new ArrayList<>();
 
     @OneToMany(mappedBy = "rival", cascade = CascadeType.ALL)
-    List<Rivalry> rivaledBy = new ArrayList<>();
+    @Builder.Default
+    private List<Rivalry> rivaledBy = new ArrayList<>();
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
     private MMR mmr;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<Leaderboard> leaderboards = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<CourtReview> courtReviews = new ArrayList<>();
 
     @OneToMany(mappedBy = "user")
-    private List<Post> posts;
+    @Builder.Default
+    private List<Post> posts = new ArrayList<>();
 
     @OneToMany(mappedBy = "user")
-    private List<Comment> comments;
+    @Builder.Default
+    private List<Comment> comments = new ArrayList<>();
+
+    // 기본 생성 메서드 (필수 매개변수만)
+    public static User createUser(String username, String nickname, String email, String password) {
+        return User.builder()
+                .username(username)
+                .nickname(nickname)
+                .email(email)
+                .password(password)
+                .build();
+    }
+
+    // 선택적 매개변수 설정 메서드들
+    public User withUserState(UserState userState) {
+        this.userState = userState;
+        return this;
+    }
+
+    public User withSocialInfo(SocialType socialType, String socialId) {
+        this.socialType = socialType;
+        this.socialId = socialId;
+        return this;
+    }
+
+    public User withUserType(UserType userType) {
+        this.userType = userType;
+        return this;
+    }
+
+    // User 엔티티 내부에 검증 로직 추가
+    public void validate() {
+        if (this.username == null || this.nickname == null || this.email == null || this.password == null) {
+            throw new IllegalArgumentException("필수항목(username/nickname/email/password)이 입력되지 않았습니다.");
+        }
+    }
 }

--- a/src/main/java/blueharmel/strokehigh/service/UserService.java
+++ b/src/main/java/blueharmel/strokehigh/service/UserService.java
@@ -17,6 +17,7 @@ public class UserService {
     //회원 가입
     @Transactional
     public Long join(User user){
+        user.validate();
         validateDuplicateUser(user);//중복 회원 검증
         userRepository.save(user);
         return user.getId();

--- a/src/test/java/blueharmel/strokehigh/service/UserServiceTest.java
+++ b/src/test/java/blueharmel/strokehigh/service/UserServiceTest.java
@@ -1,21 +1,27 @@
 package blueharmel.strokehigh.service;
 
+import blueharmel.strokehigh.domain.MatchParticipation;
 import blueharmel.strokehigh.domain.User;
 import blueharmel.strokehigh.domain.enums.UserState;
 import blueharmel.strokehigh.domain.enums.UserType;
 import blueharmel.strokehigh.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
 class UserServiceTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserServiceTest.class);
 
     @Autowired
     UserService userService;
@@ -27,7 +33,7 @@ class UserServiceTest {
     @Test
     public void 회원가입() throws Exception {
         //given
-        User user = User.builder().username("홍길동").nickname("kim").email("dldjdtjr@naver.com").password("1234").userState(UserState.valueOf("ACTIVE")).userType(UserType.valueOf("COMMON")).build();
+        User user = User.createUser("홍길동","kim","dldjtjr@naver.com", "1234").withUserState(UserState.ACTIVE).withUserType(UserType.COMMON);
         //when
         Long savedId = userService.join(user);
         //then
@@ -38,8 +44,8 @@ class UserServiceTest {
     @Test
     public void 중복_회원_예외() throws Exception {
         //given
-        User user1 = User.builder().username("홍길동").nickname("kim").email("dldjdtjr@naver.com").password("1234").userState(UserState.valueOf("ACTIVE")).userType(UserType.valueOf("COMMON")).build();
-        User user2 = User.builder().username("홍길동").nickname("kim").email("dldjdtjr@naver.com").password("1234").userState(UserState.valueOf("ACTIVE")).userType(UserType.valueOf("COMMON")).build();
+        User user1 = User.createUser("홍길동","kim","dldjtjr@naver.com", "1234").withUserState(UserState.ACTIVE).withUserType(UserType.COMMON);
+        User user2 = User.createUser("홍길동","kim","dldjtjr@naver.com", "1234").withUserState(UserState.ACTIVE).withUserType(UserType.COMMON);
         //when, then
         userService.join(user1);
         assertThrows(IllegalStateException.class, () -> {
@@ -48,14 +54,32 @@ class UserServiceTest {
     }
 
     @Test
+    public void 필수요소_모두선택_후_가입시도() throws Exception {
+        //given
+        User user = User.createUser("홍길동","kim","dldjtjr@naver.com", "1234"); // Enum은 설정된 Default 값이 반영
+        //when, then
+        userService.join(user);
+
+
+    }
+    @Test
     public void 필수요소_제외_후_가입시도() throws Exception {
         //given
-        User user1 = User.builder().username("홍길동").nickname("kim").email("dldjdtjr@naver.com").password("1234").build(); // Enum은 설정된 Default 값이 반영
-        User user2 = User.builder().username("홍길동").build();
+        User user = User.builder().username("홍길동").build();
         //when,then
-        userService.join(user1);
-        assertThrows(DataIntegrityViolationException.class, () -> {
-            userService.join(user2);
+        assertThrows(IllegalArgumentException.class, () -> {
+            userService.join(user);
         });
+    }
+
+    @Test
+    public void 신규등록_매치참여_리스트_상태확인() throws Exception {
+        //given
+        User user = User.createUser("홍길동","kim","dldjtjr@naver.com", "1234"); // Enum은 설정된 Default 값이 반영
+        //when
+        List<MatchParticipation> participations = user.getParticipations();
+        //then
+        assertEquals(0, participations.size()); // 아직 참여한 매치 없음
+        logger.info("participations = " + participations);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #8 

## 📝작업 내용

> 1. User 엔티티에 createUser라는 필수 요소 생성메서드를 만들고, 추가 요소를 포함하는 다른 메서드들 추가
> 2. 유저 엔티티 내부에 필수요소가 있는지 확인하는 validate 메서드 추가
> 3. UserServiceTest에서 신규생성 유저의 매치이력이 null인지 빈 리스트인지 확인하는 코드 추가
> 4. 테스트코드의 모든 유저 생성 부분을 createUser로 변경