### PR TITLE
[FEAT/TEST] 유저 삭제 기능 추가

### DIFF
--- a/src/main/java/blueharmel/strokehigh/StrokehighApplication.java
+++ b/src/main/java/blueharmel/strokehigh/StrokehighApplication.java
@@ -3,8 +3,10 @@ package blueharmel.strokehigh;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class StrokehighApplication {
 

--- a/src/main/java/blueharmel/strokehigh/domain/User.java
+++ b/src/main/java/blueharmel/strokehigh/domain/User.java
@@ -75,11 +75,11 @@ public class User extends DeletedTimeEntity {
     @Builder.Default
     private List<CourtReview> courtReviews = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Post> posts = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Comment> comments = new ArrayList<>();
 
@@ -115,5 +115,26 @@ public class User extends DeletedTimeEntity {
         if (this.username == null || this.nickname == null || this.email == null || this.password == null) {
             throw new IllegalArgumentException("필수항목(username/nickname/email/password)이 입력되지 않았습니다.");
         }
+    }
+
+    // 회원 탈퇴
+    public void softDelete() {
+        super.delete();
+        this.userState = UserState.INACTIVE;
+    }
+
+    // 회원 삭제
+    public void hardDelete() {
+        comments.clear();
+        posts.clear();
+        courtReviews.clear();
+        leaderboards.clear();
+        participations.clear();
+
+        rivalries.clear();
+        rivaledBy.clear();
+
+        if(mmr != null)
+            mmr = null;
     }
 }

--- a/src/main/java/blueharmel/strokehigh/repository/UserRepository.java
+++ b/src/main/java/blueharmel/strokehigh/repository/UserRepository.java
@@ -2,10 +2,10 @@ package blueharmel.strokehigh.repository;
 
 import blueharmel.strokehigh.domain.User;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -24,12 +24,32 @@ public class UserRepository {
 
     //회원 목록 조회
     public List<User> findAll() {
-        return em.createQuery("select m from User m", User.class).getResultList(); //JPQL
+        return em.createQuery("select u from User u", User.class).getResultList(); //JPQL
     }
 
     //단건 조회
     public List<User> findByName(String name){
-        return em.createQuery("select m from User m where m.nickname = :name",User.class).setParameter("name",name).getResultList();
+        return em.createQuery("select u from User u where u.nickname = :name",User.class).setParameter("name",name).getResultList();
     }
 
+    // 회원 삭제
+    public void delete(User user) {
+        em.remove(user);
+    }
+    // 회원 id로 삭제
+    public void deleteById(Long userId) {
+        User user = findOne(userId);
+        if(user != null) {
+            em.remove(user);
+        }
+    }
+    // 여러 회원 삭제
+    public void deleteAllByIds(List<Long> userIds) {
+        em.createQuery("delete from User u where u.id in :userIds").setParameter("userIds", userIds).executeUpdate();
+    }
+
+    // 비활성화된지 30일이상 된 유저 삭제
+    public void deleteAllByDeletedDate(LocalDateTime date){
+        em.createQuery("delete from User u where u.deletedAt < :date").setParameter("date",date).executeUpdate();
+    }
 }

--- a/src/test/java/blueharmel/strokehigh/service/TestEntityHelper.java
+++ b/src/test/java/blueharmel/strokehigh/service/TestEntityHelper.java
@@ -1,0 +1,15 @@
+package blueharmel.strokehigh.service;
+
+import blueharmel.strokehigh.domain.DeletedTimeEntity;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+
+@TestComponent
+public class TestEntityHelper {
+    public static void setDeletedAtForTest(DeletedTimeEntity entity, LocalDateTime deletedAt) {
+        ReflectionTestUtils.setField(entity, "deletedAt", deletedAt);
+    }
+}
+


### PR DESCRIPTION
## #️⃣연관된 이슈

> #8 

## 📝작업 내용

> 1. User 엔티티에 softDelete 메소드를 추가해 탈퇴 기능을 구현
> 2. User 엔티티에 hardDelete 메소드를 추가해 회원 완전 삭제 기능을 추가
> 3. UserRepository에 1인/id기준 1인 삭제/다인원 삭제/ deletedAt 기준 30일 지난 다인원 삭제 구현
> 4. UserService에 관련 서비스 코드 구현
> 5. UserServiceTest에 탈퇴/삭제/30일 이상 지난 인원 삭제 테스트 코드 구현
> 6. private로 설정된 deletedAt필드를 런타임 중에 수정해야해서 테스트에만 사용되는 EntityHelper 구현
> 7. EnableScheduling 어노테이션을 StrokehighApplication에 추가해 매일 0시에 deletedAt 확인후 삭제하는 기능 추가